### PR TITLE
fast_softplus: LUT replacement for log(1+exp) in AddInLogSpace (#366 item 3.2)

### DIFF
--- a/include/mathutils.h
+++ b/include/mathutils.h
@@ -89,6 +89,13 @@ const uint32_t POWER[32][128] = {
 };
 #endif
 
+// fast_softplus(d) = log(1 + exp(d)) via 64K-entry linear-interp LUT.
+// Implemented in src/fast_math.c; mirrored on the Zig side at
+// packages/zig-core/src/ham/fast_math.c. See that file for the design
+// notes (issue #366 item 3.2): replaces glibc log+exp in AddInLogSpace
+// with ~22-40% per-call speedup, accuracy 6.5e-9 max abs over [-30, 0].
+extern "C" double fast_softplus(double d);
+
 //! Takes two logd values and adds them together, i.e. takes (log a, log b) --> log a+b
 //! i.e. a *or* b
 //! \param first  log'd Double value
@@ -101,9 +108,9 @@ T AddInLogSpace(T first, T second) {
   } else if(second == -INFINITY) {
     return first;
   } else if(first > second) {
-    return first + log(1 + exp(second - first));
+    return first + fast_softplus(second - first);
   } else {
-    return second + log(1 + exp(first - second));
+    return second + fast_softplus(first - second);
   }
 }
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -38,6 +38,20 @@ for fname in glob.glob(os.getenv('PWD') + '/src/*.cc'):
         # sources.append(fname.replace('src/', '_build/'))
         sources.append(fname)  # seems to work fine this was as well for me, and in this issue someone had it break with the previous line https://github.com/psathyrella/ham/issues/16
 
+# fast_math.c — C source (the env's *.cc glob above does not pick it up).
+# Built with -ffp-contract=off so the linear-interp arithmetic in
+# fast_softplus is bit-deterministic across compilers (and matches the
+# Zig mirror at packages/zig-core/src/ham/fast_math.c). The other ham
+# sources don't carry that flag because they don't need cross-backend
+# bit equality.
+fast_math_c = os.path.join(os.getenv('PWD'), 'src', 'fast_math.c')
+fast_math_obj = env.Object(
+    target='fast_math',
+    source=fast_math_c,
+    CCFLAGS=['-O3', '-ffp-contract=off', '-fno-builtin'],
+)
+sources.append(fast_math_obj)
+
 env.Library(target='ham', source=sources)
 
 for bname in binary_names:

--- a/src/fast_math.c
+++ b/src/fast_math.c
@@ -1,0 +1,80 @@
+/* fast_math.c — fast log-sum-exp via tabulated softplus.
+ *
+ * Drop-in replacement for the `log(1 + exp(d))` work in AddInLogSpace
+ * (mathutils.h:98). Replaces 1 log + 1 exp glibc call (~5–17 ns combined,
+ * arch-dependent) with a single 65 K-entry linear-interpolation lookup
+ * (~3.5–10 ns per call).
+ *
+ * Pre-flight measurements at issue #366 item 3.2:
+ *   - Zen 5 (glibc 2.39): glibc 9.6 ns → LUT64K 7.3 ns per addInLogSpace
+ *   - Broadwell:          glibc 16.7 ns → LUT64K 10.0 ns
+ *   - LUT64K accuracy: max abs error 6.5e-9 over [-30, 0] (5 orders under
+ *     the partis-test 1e-5 gate).
+ *
+ * Why a 65 K linear-interp table:
+ *   The Cephes scalar polynomial alternative (~7-15 ns) loses to modern
+ *   glibc's FMA-optimized scalar log/exp on every CPU we tested. LUT
+ *   wins because it replaces ~10 ALU ops + branches with a single load
+ *   + 1 multiply + 1 fma. Smaller LUTs (256, 4 K, 16 K) fail the worst-
+ *   case error budget; LUT64K passes by 4×. Cubic interp at 1 K entries
+ *   would also pass speed-wise but not accuracy-wise.
+ *
+ * The linear-interp arithmetic dominates over the table size in cycle
+ * count (LUT256 ≈ LUT64K on every benchmarked CPU), so going larger is
+ * effectively free as long as the hot region stays cache-resident — and
+ * it does, because real DP traffic concentrates near d = 0.
+ *
+ * Built with -O3 -ffp-contract=off so that the linear-interp arithmetic
+ * is bit-deterministic across g++/clang/zig from the same C source.
+ * (Without that flag, cross-compiler drift would be 1–2 ULP — far under
+ * the partis-test gate, but bit-equality between backends is cheap to
+ * keep so we keep it.)
+ *
+ * Mirrored on the Zig side at packages/zig-core/src/ham/fast_math.c.
+ * Both sides MUST stay in sync; the table is data so cross-backend
+ * parity is trivial as long as the same source compiles to both.
+ */
+#include <math.h>
+
+/* Range of d for which the table covers softplus(d) = log(1 + exp(d))
+ * directly. Outside this range, we use the closed-form fall-throughs:
+ *   d < LUT_LO:  exp(d) is well under double precision, softplus ≈ 0.
+ *   d > 0:       use the symmetry softplus(d) = d + softplus(-d).
+ *
+ * Within addInLogSpace's standard form (see mathutils.h AddInLogSpace),
+ * the argument is always (smaller - larger) ≤ 0. The d > 0 branch is
+ * defensive — should not be exercised in practice, but keeps the
+ * function safe to call independently.
+ */
+#define LUT_N  65536
+#define LUT_LO -30.0
+#define LUT_HI 0.0
+
+static double softplus_lut[LUT_N + 1];
+
+/* (LUT_N / |LUT_LO|) precomputed for the index calculation. Using a
+ * macro keeps it a compile-time constant, which the compiler can fold
+ * into the multiply at the call site. */
+#define LUT_SCALE ((double) LUT_N / -(LUT_LO))
+
+__attribute__((constructor))
+static void init_softplus_lut(void) {
+    /* log1p(exp(d)) is the numerically stable form of log(1 + exp(d))
+     * for the table-build phase. Build is one-shot at process start. */
+    for (int i = 0; i <= LUT_N; ++i) {
+        double d = LUT_LO + (LUT_HI - LUT_LO) * (double) i / (double) LUT_N;
+        softplus_lut[i] = log1p(exp(d));
+    }
+}
+
+double fast_softplus(double d) {
+    if (d < LUT_LO) return 0.0;
+    if (d > 0.0)    return d + fast_softplus(-d);   /* symmetry */
+    /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
+    double t = (d - LUT_LO) * LUT_SCALE;
+    int i = (int) t;
+    double frac = t - (double) i;
+    double y0 = softplus_lut[i];
+    double y1 = softplus_lut[i + 1];
+    return y0 + frac * (y1 - y0);
+}


### PR DESCRIPTION
## Summary

Drop-in LUT replacement for the \`log(1 + exp(d))\` work in \`AddInLogSpace\`. Saves **15% of partis wall** and **20% of bcrham wall** on a 5k paired partition (median-of-3, AMD Zen 5; bigger wins on older Intel/AMD).

For psathyrella/partis#366 item 3.2. **Mirrors a Zig-side change in [partis PR — pending]**; both sides ship together per the [#366 re-pin procedure](https://github.com/psathyrella/partis/issues/366#issuecomment-4391141047).

## What changed

- New: \`src/fast_math.c\` — 65 K-entry linear-interpolation LUT of softplus(d) over [-30, 0] with d > 0 symmetry fall-through and d < -30 underflow short-circuit. Built with \`-O3 -ffp-contract=off -fno-builtin\` for cross-compiler bit-determinism.
- \`include/mathutils.h\`: \`AddInLogSpace<T>\` now calls \`fast_softplus(b - a)\` instead of \`log(1 + exp(b - a))\`. \`extern \"C\"\` declaration added.
- \`src/SConscript\`: explicit \`env.Object\` for \`fast_math.c\` (the existing \`*.cc\` glob does not pick up \`.c\` files).

## Why LUT, not Cephes polynomial

Pre-flight cross-arch microbench (Zen 3, Zen 4, Zen 5, Intel Broadwell — all glibc 2.39) showed:

- **Cephes scalar polynomial loses to glibc 2.39 on every architecture.** Modern glibc ships FMA-optimized scalar log/exp (\`__ieee754_log_fma\`/\`__ieee754_exp_fma\`); scalar Horner can't beat them.
- **LUT linear-interp wins on every arch** (22-41% per addInLogSpace call). Linear-interp ALU pipeline (1 mul + 1 fma) dominates over table lookup, so larger tables are essentially free up to L2 size.
- LUT256 (the design originally floated in [PERF-NEXT.md](https://github.com/psathyrella/partis/blob/366-zig-perf-next/packages/zig-core/PERF-NEXT.md)) fails accuracy by 5 orders of magnitude. LUT64K passes by 4×.

Full data tables and microbench source in #366 comment.

## Accuracy

LUT64K linear interp: max abs error 6.5e-9 over [-30, 0]. The partis-test gate is 1e-5 on output log-probs — 4 orders of magnitude headroom even after worst-case signed-error accumulation across 10⁵ calls per query.

Verified at the partis level:
- 100-query paired partition: bit-identical naive seqs, V/D/J calls, deletions, insertions
- 5k paired partition (3797 + 3802 events): bit-identical
- Cross-backend: C++ fast_softplus ≡ Zig fast_softplus ≡ glibc baseline

## Wall measurement (5k paired, median-of-3 on pax / Zen 5)

|  | C++ | Zig |
|---|---|---|
| wall before | 397.0 s | 291.4 s |
| wall after | 336.4 s | 222.5 s |
| partis savings | **15.3%** | **23.7%** |
| bcrham savings | **20.1%** | **33.8%** |

The C++ savings match the original 15-20% projection. Zig substantially exceeds it — the dlopen wrapper overhead in \`glibc_log\` / \`glibc_exp\` (which #366 perf-record showed as ~3% of total cycles) is also eliminated by the switch to \`fast_softplus\`.

## Test plan

- [x] bcrham builds (gcc compiles \`fast_math.c\` correctly via SConscript change)
- [x] Symbol \`fast_softplus\` linked into bcrham (\`nm\` confirmed)
- [x] Partis-test (non-paired, full): 0 / 14 logprobs differ, 0 / 40 naive seqs differ
- [x] Partis-test --paired: passes (env-side R failure on simulate stage is pre-existing, unrelated)
- [x] Cross-backend parity at 5k paired
- [x] Wall measurement (median-of-3 5k paired)
- [ ] After merge: tag the commit (cpp-tag) for partis to pin
- [ ] partis-side PR: bump submodule, mirror Zig source

🤖 Generated with [Claude Code](https://claude.com/claude-code)