### PR TITLE
promote float→double for mute_freq, threshold args, RecoEvent::score (partis #377)

### DIFF
--- a/include/args.h
+++ b/include/args.h
@@ -29,10 +29,10 @@ public:
   string input_cachefname() { return input_cachefname_arg_.getValue(); }
   string output_cachefname() { return output_cachefname_arg_.getValue(); }
   string locus() { return locus_arg_.getValue(); }
-  float hamming_fraction_bound_lo() { return hamming_fraction_bound_lo_arg_.getValue(); }
-  float hamming_fraction_bound_hi() { return hamming_fraction_bound_hi_arg_.getValue(); }
-  float logprob_ratio_threshold() { return logprob_ratio_threshold_arg_.getValue(); }
-  float max_logprob_drop() { return max_logprob_drop_arg_.getValue(); }
+  double hamming_fraction_bound_lo() { return hamming_fraction_bound_lo_arg_.getValue(); }
+  double hamming_fraction_bound_hi() { return hamming_fraction_bound_hi_arg_.getValue(); }
+  double logprob_ratio_threshold() { return logprob_ratio_threshold_arg_.getValue(); }
+  double max_logprob_drop() { return max_logprob_drop_arg_.getValue(); }
   string algorithm() { return algorithm_arg_.getValue(); }
   string ambig_base() { return ambig_base_arg_.getValue(); }
   string seed_unique_id() { return seed_unique_id_arg_.getValue(); }
@@ -59,7 +59,7 @@ public:
   ValuesConstraint<string> algo_vals_;
   ValuesConstraint<int> debug_vals_;
   ValueArg<string> hmmdir_arg_, datadir_arg_, infile_arg_, outfile_arg_, annotationfile_arg_, input_cachefname_arg_, output_cachefname_arg_, locus_arg_, algorithm_arg_, ambig_base_arg_, seed_unique_id_arg_;
-  ValueArg<float> hamming_fraction_bound_lo_arg_, hamming_fraction_bound_hi_arg_, logprob_ratio_threshold_arg_, max_logprob_drop_arg_;
+  ValueArg<double> hamming_fraction_bound_lo_arg_, hamming_fraction_bound_hi_arg_, logprob_ratio_threshold_arg_, max_logprob_drop_arg_;
   ValueArg<int> debug_arg_, naive_hamming_cluster_arg_, biggest_naive_seq_cluster_to_calculate_arg_, biggest_logprob_cluster_to_calculate_arg_, n_partitions_to_write_arg_;
   ValueArg<unsigned> n_final_clusters_arg_, min_largest_cluster_size_arg_, max_cluster_size_arg_, random_seed_arg_;
   SwitchArg no_chunk_cache_arg_, partition_arg_, dont_rescale_emissions_arg_, cache_naive_seqs_arg_, cache_naive_hfracs_arg_, only_cache_new_vals_arg_, write_logprob_for_each_partition_arg_;

--- a/include/bcrutils.h
+++ b/include/bcrutils.h
@@ -83,7 +83,7 @@ public:
   map<string, size_t> deletions_;
   map<string, string> insertions_;
   string naive_seq_;
-  float score_;
+  double score_;
   int cyst_position_, tryp_position_, cdr3_length_;
   map<string, vector<SupportPair> >  per_gene_support_;  // for each region, a sorted list of (gene, logprob) pairs
 

--- a/include/glomerator.h
+++ b/include/glomerator.h
@@ -24,7 +24,7 @@ typedef pair<vector<string>, vector<string> > ClusterPair;
 class Query {
 public:
   Query() {}
-  Query(string name, vector<Sequence*> seqs, bool seed_missing, vector<string> only_genes, KBounds kbounds, float mute_freq, size_t cdr3_length, string p1="", string p2="") :
+  Query(string name, vector<Sequence*> seqs, bool seed_missing, vector<string> only_genes, KBounds kbounds, double mute_freq, size_t cdr3_length, string p1="", string p2="") :
     name_(name),
     seqs_(seqs),
     seed_missing_(seed_missing),
@@ -47,7 +47,7 @@ public:
   bool seed_missing_;
   vector<string> only_genes_;
   KBounds kbounds_;
-  float mute_freq_;
+  double mute_freq_;
   size_t cdr3_length_;
   pair<string, string> parents_;  // queries that were joined to make this
 };

--- a/src/bcrutils.cc
+++ b/src/bcrutils.cc
@@ -249,16 +249,16 @@ void Result::Finalize(GermLines &gl, map<string, double> &unsorted_per_gene_supp
 
   // sort vector of events by score (i.e. find the best path over ksets)
   // STABLE descending sort so tied events resolve to the first-pushed kset
-  // (deterministic across runs and backends). RecoEvent::score_ is float
-  // (intentionally — single-precision storage matches the historical hmm
-  // contract), so two ksets with f64 scores within ~1e-6 collapse to identical
-  // float values; an unstable sort then picks an algorithm-dependent winner
-  // that disagrees between C++ introsort and Zig pdqsort. Stable sort + a
-  // descending comparator picks the first-pushed tied event in both backends
-  // (push order is the kset reverse-iteration k_v=vmax-1..vmin, k_d=dmax-1..dmin
-  // — see DPHandler::Run), which propagates through naive_seq → hfrac → cluster
-  // merges and was the proximate cause of the 30k Zig-vs-C++ partition divergence
-  // reported in partis issue #375.
+  // (deterministic across runs and backends). With RecoEvent::score_ stored as
+  // double (partis issue #377), genuine f32 collapse no longer happens — but
+  // two ksets can still produce machine-epsilon-equal f64 scores, and we still
+  // want the tie-break to be deterministic across stdlib sort algorithms (C++
+  // introsort vs. Zig pdqsort, which pick different winners on ties). Stable
+  // sort + a descending comparator picks the first-pushed tied event in both
+  // backends (push order is the kset reverse-iteration k_v=vmax-1..vmin,
+  // k_d=dmax-1..dmin — see DPHandler::Run). Originally added in #375 to mask
+  // an upstream f32-narrowing collapse; #377 fixed the narrowings, this kept
+  // the deterministic-tie-break invariant.
   stable_sort(events_.begin(), events_.end(), [](const RecoEvent &a, const RecoEvent &b) { return a.score_ > b.score_; });
   best_event_ = events_[0];
 


### PR DESCRIPTION
## Summary

Promote three remaining `float` storage sites to `double` in ham, on the C++ side
of the coordinated [cpp-mirror] change for partis issue
[#377](https://github.com/psathyrella/partis/issues/377). Closes the latent
narrow-then-widen patterns that PR
[#19](https://github.com/psathyrella/ham/pull/19) — sorry, partis
[#376](https://github.com/psathyrella/partis/pull/376) — pinned via stable_sort.

The narrowings were: (1) `Query::mute_freq_` (feeds `Model::RescaleOverallMuteFreq`,
which scales emission probabilities), (2) four cluster-merge threshold args
(`hamming_fraction_bound_lo/hi`, `logprob_ratio_threshold`, `max_logprob_drop` —
compared against `f64` quantities in the merge loop), and (3) `RecoEvent::score_`
(the field that #375 traced to the 30k Zig-vs-C++ partition divergence — two
ksets with `f64` Viterbi scores within ~1e-6 collapsed to identical `f32` values).

The `stable_sort` block in `Result::Finalize` stays — at `f64` precision two
ksets can still produce machine-epsilon-equal scores, and we still want
deterministic tie-breaking across stdlib sort algorithms. Comment rewritten
to reflect the post-#377 invariant.

This is a [cpp-mirror] change: the matching Zig side bump is in partis PR for
issue #377.

## Files changed

- `include/glomerator.h` — `Query::mute_freq_` and ctor param `float` → `double`
- `include/args.h` — four threshold getters and the `ValueArg<>` template type `float` → `double`
- `include/bcrutils.h` — `RecoEvent::score_` `float` → `double`
- `src/bcrutils.cc` — comment rewrite at the `stable_sort` site

## Test plan

- [x] `scons bcrham` builds clean
- [ ] partis side `bin/partis-test.py --paired --no-simu` regression
- [ ] partis side `bin/partis-30k-parity-test.sh` Zig-vs-C++ bit-equal

The `args.cc` ctor calls `ValueArg<float>(... 0.0, "float")` resolve their
template type from the declaration in `args.h` — the trailing `"float"` strings
are TCLAP help-text only and stay as-is per #377.

## Branch base

This branch (`377-float-to-double`) is stacked on `375-stable-sort-events`
(PR [#20](https://github.com/psathyrella/ham/pull/20)). It will rebase onto
`main` once #20 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
